### PR TITLE
Implement the "IMMDeviceCollection" to find all devices of a given type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e196f430604fcd7503056c5aaa7dfc5bc570582b928240622b075b5cad3b90dd"
+
+[[package]]
 name = "blocking"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,7 +631,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -894,6 +900,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-std",
+ "bitflags 2.0.0-rc.1",
  "log",
  "num_enum",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4"
 anyhow = "1.0"
 thiserror = "1.0"
 num_enum = "0.5.7"
+bitflags = "2.0.0-rc.1"
 
 [dependencies.windows]
 version = "0.43"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,11 +1,13 @@
 ///"Type" enums
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyValueError, prelude::*};
 
+use bitflags::bitflags;
 use num_enum::TryFromPrimitive;
 
 use windows::Win32::Media::Audio::{
-    eAll, eCapture, eCommunications, eConsole, eMultimedia, eRender, DEVICE_STATE_ACTIVE,
-    DEVICE_STATE_DISABLED, DEVICE_STATE_NOTPRESENT, DEVICE_STATE_UNPLUGGED,
+    eAll, eCapture, eCommunications, eConsole, eMultimedia, eRender, EDataFlow,
+    DEVICE_STATEMASK_ALL, DEVICE_STATE_ACTIVE, DEVICE_STATE_DISABLED, DEVICE_STATE_NOTPRESENT,
+    DEVICE_STATE_UNPLUGGED,
 };
 
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, Clone, Copy)]
@@ -20,6 +22,12 @@ pub enum DataFlow {
     All = eAll.0,
 }
 
+impl From<DataFlow> for EDataFlow {
+    fn from(e: DataFlow) -> Self {
+        EDataFlow(e as i32)
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, Clone, Copy)]
 #[pyclass(name = "Role")]
 #[repr(i32)]
@@ -32,16 +40,62 @@ pub enum Role {
     Multimedia = eMultimedia.0,
 }
 
-#[derive(Debug, Eq, PartialEq, TryFromPrimitive, Clone, Copy)]
-#[pyclass(name = "DeviceState")]
-#[repr(u32)]
-pub enum DeviceState {
-    #[pyo3(name = "ACTIVE")]
-    Active = DEVICE_STATE_ACTIVE,
-    #[pyo3(name = "DISABLED")]
-    Disabled = DEVICE_STATE_DISABLED,
-    #[pyo3(name = "NOT_PRESENT")]
-    NotPresent = DEVICE_STATE_NOTPRESENT,
-    #[pyo3(name = "UNPLUGGED")]
-    Unplugged = DEVICE_STATE_UNPLUGGED,
+bitflags! {
+    #[derive(Debug, Eq, PartialEq, Clone, Copy)]
+    pub struct DeviceState: u32 {
+        const Active = DEVICE_STATE_ACTIVE;
+        const Disabled = DEVICE_STATE_DISABLED;
+        const NotPresent = DEVICE_STATE_NOTPRESENT;
+        const Unplugged = DEVICE_STATE_UNPLUGGED;
+        const All = DEVICE_STATEMASK_ALL;
+    }
+}
+
+impl DeviceState {
+    pub fn py_name(self) -> &'static str {
+        match self {
+            DeviceState::Active => "ACTIVE",
+            DeviceState::Disabled => "DISABLED",
+            DeviceState::NotPresent => "NOT_PRESENT",
+            DeviceState::Unplugged => "UNPLUGGED",
+            DeviceState::All => "ALL",
+            _ => panic!("Unexpected value"),
+        }
+    }
+}
+
+impl From<DeviceState> for u32 {
+    fn from(value: DeviceState) -> u32 {
+        value.bits()
+    }
+}
+impl From<u32> for DeviceState {
+    fn from(value: u32) -> DeviceState {
+        DeviceState::from_bits_truncate(value)
+    }
+}
+
+impl ToPyObject for DeviceState {
+    fn to_object(&self, py: Python) -> PyObject {
+        self.bits().into_py(py)
+    }
+}
+
+impl IntoPy<PyObject> for DeviceState {
+    fn into_py(self, py: Python) -> PyObject {
+        self.to_object(py)
+    }
+}
+
+impl<'source> FromPyObject<'source> for DeviceState {
+    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+        let raw = u32::extract(obj)?;
+        match DeviceState::from_bits(raw) {
+            None => Err(PyValueError::new_err(format!(
+                "Failed to extract `DeviceState` from {:?}",
+                raw
+            ))),
+            Some(flags) => Ok(flags),
+        }
+    }
 }

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,7 +1,8 @@
 import os
+import sys
 import pytest
 
-from windows_audio_events import DeviceCollection, AudioDevice
+from windows_audio_events import DeviceCollection, AudioDevice, DeviceState, DataFlow
 
 
 @pytest.fixture(scope="module")
@@ -16,3 +17,17 @@ def test_import(collection: DeviceCollection):
 @pytest.mark.skipif(int(os.environ.get('NUM_AUDIO_DEVICES', '1')) <= 0, reason="No audio devices found")
 def test_default_output(collection: DeviceCollection):
     assert isinstance(collection.get_default_output_device(), AudioDevice)
+
+
+@pytest.mark.parametrize(
+    ["state"],
+    [[DeviceState.ACTIVE], [DeviceState.ACTIVE | DeviceState.UNPLUGGED], [DeviceState.ALL]],
+    ids=lambda state: state.name,
+)
+def test_device_filter(state, collection: DeviceCollection):
+    devices = collection.devices(DataFlow.RENDER, state)
+    # We can't test anything we get back, just that we have a length
+    assert isinstance(len(devices), int)
+
+    with pytest.raises(IndexError):
+        devices[sys.maxsize]


### PR DESCRIPTION
Since the DeviceState needs to be a bit-wise OR mask, the standard rust
enum and pyo3's expsoing of that to python wasn't enough, so I had to to
"manually" create the IntFlag enum myself
